### PR TITLE
Fix chart caching

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -10,7 +10,10 @@ function ChartController(options) {
   this.node = options.node;
   this.blocks = options.blocks;
 
-  this.chartCache = LRU(options.chartCacheSize || ChartController.DEFAULT_CHART_CACHE_SIZE);
+  this.chartCache = LRU({
+      max: options.chartCacheSize || ChartController.DEFAULT_CHART_CACHE_SIZE,
+      maxAge: 1000 * 60
+  });
 
   this.common = new Common({log: this.node.log});
 }


### PR DESCRIPTION
For some reason, the chart cache was not configured with a maximum age.
This causes charts to only generate once and always serve the cached
chart data.

I've added a maxAge to the chart cache instantiation that is equivalent
to the SAFE block time.